### PR TITLE
Updates instance address on changeAddress

### DIFF
--- a/src/SparkFun_VL6180X.cpp
+++ b/src/SparkFun_VL6180X.cpp
@@ -131,7 +131,7 @@ uint8_t VL6180x::changeAddress(uint8_t old_address, uint8_t new_address){
   if( new_address > 127) return old_address;
    
    VL6180x_setRegister(VL6180X_I2C_SLAVE_DEVICE_ADDRESS, new_address);
-   
+   _i2caddress = new_address;
    return VL6180x_getRegister(VL6180X_I2C_SLAVE_DEVICE_ADDRESS); 
 }
   


### PR DESCRIPTION
Fixes a bug where the instance's address is not updated when a changeAddress command is sent to the VL6180. Behavior specified in line 170 in the header file is now working.
