### PR TITLE
removed Wire.begin

### DIFF
--- a/src/SparkFun_VL6180X.cpp
+++ b/src/SparkFun_VL6180X.cpp
@@ -32,7 +32,6 @@
 VL6180x::VL6180x(uint8_t address)
 // Initialize the Library
 {
-  Wire.begin(); // Arduino Wire library initializer
   _i2caddress = address; //set default address for communication
 }
 


### PR DESCRIPTION
needs to be used in main code instead, otherwise it cannot compile on adafruit feather M0, and possibly also ESP8266.
